### PR TITLE
fix #3

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -15,7 +15,7 @@
     <input type="text" name="day" placeholder="Day (e.g., Monday)" required>
     <input type="text" name="time" placeholder="HH:MM" required aria-label="Time in HH:MM format">
 
-    <button type="submit" class="btn-primary">Add Task</button>
+    <button type="submit" class="btn-primary">Add to Timetable</button>
   </form>
 
   <div id="timetable-list">


### PR DESCRIPTION
This pull request addresses issue #3: Form Button Mislabel
Change the “Add Task” button text to “Add to Timetable” by modifying the button’s innerText in HTML.

Closes #3