### PR TITLE
fix #12

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1,2 +1,16 @@
 // Add any specific JavaScript code here if needed in the future
 console.log("task added");
+
+document.addEventListener('DOMContentLoaded', () => {
+    const currentDay = new Date().toLocaleString('en-us', { weekday: 'long' }); // Get today's day (e.g., "Monday")
+    const tasks = document.querySelectorAll('.task');
+  
+    tasks.forEach(task => {
+      const dayText = task.querySelector('p:nth-child(2)').innerText; // "Day: Monday" text
+      const day = dayText.split(': ')[1]; // Extract day from "Day: Monday"
+  
+      if (day === currentDay) {
+        task.classList.add('active-day'); // Apply .active-day if it matches current day
+      }
+    });
+  });

--- a/public/style.css
+++ b/public/style.css
@@ -76,6 +76,11 @@ body {
     background-color: #424eef; /* Darker shade for hover */
   }
   
+  .active-day {
+    border: 2px solid #ff9d00; /* Highlight color for today's tasks */
+    background-color: #fffbe6; /* Slightly different background */
+  }
+  
   @media (max-width: 600px) {
     #timetable-list {
         width: 100%; /* Full width on smaller screens */


### PR DESCRIPTION
This pull request addresses issue #12: Highlight Active Day Tasks
Use JavaScript to dynamically apply a CSS class (e.g., .active-day) to tasks scheduled for the current day.

Closes #12